### PR TITLE
Add refresh on app foreground with 30s throttle

### DIFF
--- a/LeaveAlready/AppState.swift
+++ b/LeaveAlready/AppState.swift
@@ -9,6 +9,7 @@ class AppState: ObservableObject {
     @Published var showSettings = false
 
     private var cancellables = Set<AnyCancellable>()
+    private var lastRefreshTime: Date?
 
     init() {
         // When location updates, find nearest route
@@ -32,6 +33,7 @@ class AppState: ObservableObject {
     }
 
     func refresh() {
+        lastRefreshTime = Date()
         locationManager.requestLocation()
 
         if let route = activeRoute {
@@ -39,6 +41,16 @@ class AppState: ObservableObject {
                 await transitService.fetchDepartures(for: route)
             }
         }
+    }
+
+    /// Refreshes only if 30+ seconds have passed since the last refresh
+    func refreshIfNeeded() {
+        let threshold: TimeInterval = 30
+        if let lastRefresh = lastRefreshTime,
+           Date().timeIntervalSince(lastRefresh) < threshold {
+            return
+        }
+        refresh()
     }
 
     func fetchDepartures() {

--- a/LeaveAlready/LeaveAlreadyApp.swift
+++ b/LeaveAlready/LeaveAlreadyApp.swift
@@ -3,11 +3,17 @@ import SwiftUI
 @main
 struct LeaveAlreadyApp: App {
     @StateObject private var appState = AppState()
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(appState)
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                appState.refreshIfNeeded()
+            }
         }
     }
 }


### PR DESCRIPTION
Refreshes departure data when the app returns to the foreground,
but only if there hasn't been a refresh in the last 30 seconds.