### PR TITLE
Fix JSON decoding error for 511.org API response

### DIFF
--- a/LeaveAlready/Models/Departure.swift
+++ b/LeaveAlready/Models/Departure.swift
@@ -37,7 +37,7 @@ struct APIResponse: Codable {
 }
 
 struct ServiceDelivery: Codable {
-    let StopMonitoringDelivery: StopMonitoringDelivery
+    let StopMonitoringDelivery: [StopMonitoringDelivery]
 }
 
 struct StopMonitoringDelivery: Codable {

--- a/LeaveAlready/Services/TransitService.swift
+++ b/LeaveAlready/Services/TransitService.swift
@@ -83,7 +83,8 @@ class TransitService: ObservableObject {
     }
 
     private func parseDepartures(from response: APIResponse, for route: ActiveRoute) -> [Departure] {
-        guard let visits = response.ServiceDelivery.StopMonitoringDelivery.MonitoredStopVisit else {
+        guard let delivery = response.ServiceDelivery.StopMonitoringDelivery.first,
+              let visits = delivery.MonitoredStopVisit else {
             return []
         }
 


### PR DESCRIPTION
The 511.org API returns StopMonitoringDelivery as an array, not a single
object. Updated the model to expect an array and parse the first element.